### PR TITLE
Hotfix: getWireguardConfig, TS logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<p>
-<img src="/docs/assets/tunnelsats_banner_1280_640.png" width="640" title="TunnelSats Banner" />
-</p>
+![TunnelSats Banner](/docs/assets/tunnelsats_banner_1280_640.png)
 
 <br/>
 

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -617,7 +617,7 @@ async function getWireguardConfig(publicKey, presharedKey, timestamp, server) {
       publicKey: publicKey,
       presharedKey: presharedKey,
       bwLimit: 100000, // 100GB
-      subExpiry: parseBackendDate(timestamp),
+      subExpiry: parseDate(timestamp),
       ipIndex: 0,
     },
   };


### PR DESCRIPTION
Fixes a broken API call in getWireguardConfig (server.js) and the TS logo at the guide webpage. 