### PR TITLE
Reconfigure VPN handling

### DIFF
--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -376,7 +376,7 @@ function App() {
         renderPopupModal();
         DEBUG && console.log(result);
         setSpinnerQuery(false);
-      } else if (typeof result === "string") {
+      } else if (result.data.match("not-allowed")) {
         errorMessage = "Server capacity limit reached. Please buy a new subscription from the same continent.";
       } else if (typeof result === "object") {
         keyID = result.keyID;

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -101,7 +101,7 @@ function App() {
   const [isPopupModal, showPopupModal] = useState(false);
   const renderPopupModal = () => showPopupModal(true);
   const hidePopupModal = () => showPopupModal(false);
-  let popupMessage = "";
+  const [popupMessage, setPopupMessage] = useState("");
 
   // special discounts
   const [discount, setDiscount] = useState(1.0);
@@ -368,7 +368,7 @@ function App() {
       DEBUG && console.log("%o", result);
 
       if (result == null) {
-        popupMessage = "The provided WireGuard pubkey was not found on any server!";
+        setPopupMessage("The provided WireGuard pubkey was not found on any server!");
         setTime("");
         setNewTime("");
         setTimeValid(false);
@@ -377,7 +377,7 @@ function App() {
         DEBUG && console.log(result);
         setSpinnerQuery(false);
       } else if (result.data.match("not-allowed")) {
-        popupMessage = "Server capacity limit reached. Please buy a new subscription from the same continent.";
+        setPopupMessage("Server capacity limit reached. Please buy a new subscription from the same continent.");
       } else if (typeof result === "object") {
         keyID = result.keyID;
 

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -387,6 +387,7 @@ function App() {
         setTimeValid(false);
         setTimeValidOld(false);
         renderPopupModal();
+        DEBUG && console.log(result);        
         setSpinnerQuery(false);
       } else if (typeof result === "object") {
         keyID = result.keyID;

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -368,7 +368,9 @@ function App() {
       DEBUG && console.log("%o", result);
 
       if (result == null) {
-        setPopupMessage("The provided WireGuard pubkey was not found on any server!");
+        setPopupMessage(
+          "The provided WireGuard pubkey was not found on any server!"
+        );
         setTime("");
         setNewTime("");
         setTimeValid(false);
@@ -377,7 +379,9 @@ function App() {
         DEBUG && console.log(result);
         setSpinnerQuery(false);
       } else if (result == "not-allowed") {
-        setPopupMessage("Server capacity limit reached. Please buy a new subscription from the same continent.");
+        setPopupMessage(
+          "Server capacity limit reached. Please buy a new subscription from the same continent."
+        );
         setTime("");
         setNewTime("");
         setTimeValid(false);

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -101,6 +101,7 @@ function App() {
   const [isPopupModal, showPopupModal] = useState(false);
   const renderPopupModal = () => showPopupModal(true);
   const hidePopupModal = () => showPopupModal(false);
+  let errorMessage = "";
 
   // special discounts
   const [discount, setDiscount] = useState(1.0);
@@ -367,6 +368,7 @@ function App() {
       DEBUG && console.log("%o", result);
 
       if (result == null) {
+        errorMessage = "The provided WireGuard pubkey was not found on any server!";
         setTime("");
         setNewTime("");
         setTimeValid(false);
@@ -374,6 +376,8 @@ function App() {
         renderPopupModal();
         DEBUG && console.log(result);
         setSpinnerQuery(false);
+      } else if (typeof result === "string") {
+        errorMessage = "Server capacity limit reached. Please buy a new subscription from the same continent.";
       } else if (typeof result === "object") {
         keyID = result.keyID;
 
@@ -824,9 +828,7 @@ function App() {
               <Popup
                 show={isPopupModal}
                 title={"⚠️ Error"}
-                errorMessage={
-                  "The provided WireGuard pubkey was not found on any server!"
-                }
+                errorMessage={errorMessage}
                 handleClose={hidePopupModal}
               />
             ) : null}

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -378,6 +378,11 @@ function App() {
         setSpinnerQuery(false);
       } else if (result.data.match("not-allowed")) {
         setPopupMessage("Server capacity limit reached. Please buy a new subscription from the same continent.");
+        setTime("");
+        setNewTime("");
+        setTimeValid(false);
+        setTimeValidOld(false);
+        renderPopupModal();        
       } else if (typeof result === "object") {
         keyID = result.keyID;
 

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -376,7 +376,7 @@ function App() {
         renderPopupModal();
         DEBUG && console.log(result);
         setSpinnerQuery(false);
-      } else if (result.data.match("not-allowed")) {
+      } else if (result == "not-allowed") {
         setPopupMessage("Server capacity limit reached. Please buy a new subscription from the same continent.");
         setTime("");
         setNewTime("");

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -101,7 +101,7 @@ function App() {
   const [isPopupModal, showPopupModal] = useState(false);
   const renderPopupModal = () => showPopupModal(true);
   const hidePopupModal = () => showPopupModal(false);
-  let errorMessage = "";
+  let popupMessage = "";
 
   // special discounts
   const [discount, setDiscount] = useState(1.0);
@@ -368,7 +368,7 @@ function App() {
       DEBUG && console.log("%o", result);
 
       if (result == null) {
-        errorMessage = "The provided WireGuard pubkey was not found on any server!";
+        popupMessage = "The provided WireGuard pubkey was not found on any server!";
         setTime("");
         setNewTime("");
         setTimeValid(false);
@@ -377,7 +377,7 @@ function App() {
         DEBUG && console.log(result);
         setSpinnerQuery(false);
       } else if (result.data.match("not-allowed")) {
-        errorMessage = "Server capacity limit reached. Please buy a new subscription from the same continent.";
+        popupMessage = "Server capacity limit reached. Please buy a new subscription from the same continent.";
       } else if (typeof result === "object") {
         keyID = result.keyID;
 
@@ -828,7 +828,7 @@ function App() {
               <Popup
                 show={isPopupModal}
                 title={"⚠️ Error"}
-                errorMessage={errorMessage}
+                errorMessage={popupMessage}
                 handleClose={hidePopupModal}
               />
             ) : null}

--- a/frontend/client/src/App.js
+++ b/frontend/client/src/App.js
@@ -382,7 +382,8 @@ function App() {
         setNewTime("");
         setTimeValid(false);
         setTimeValidOld(false);
-        renderPopupModal();        
+        renderPopupModal();
+        setSpinnerQuery(false);
       } else if (typeof result === "object") {
         keyID = result.keyID;
 

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -413,7 +413,7 @@ io.on("connection", (socket) => {
                 logDim("SubscriptionEnd: ", date.toISOString());
                 subscriptionEnd = date;
 
-                if (domain == "de1.tunnelsats.com") {
+                if (domain.match("de1.tunnelsats.com")) {
                   socket.emit("receiveKeyLookup", "not-allowed");
                 } else {
                   socket.emit("receiveKeyLookup", {

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -413,7 +413,7 @@ io.on("connection", (socket) => {
                 logDim("SubscriptionEnd: ", date.toISOString());
                 subscriptionEnd = date;
 
-                if (domain.match("de1.tunnelsats.com")) {
+                if (domain.match(servers[0].domain)) {
                   socket.emit("receiveKeyLookup", "not-allowed");
                 } else {
                   socket.emit("receiveKeyLookup", {

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -413,7 +413,7 @@ io.on("connection", (socket) => {
                 logDim("SubscriptionEnd: ", date.toISOString());
                 subscriptionEnd = date;
 
-                if (domain.includes("de1.tunnelsats.com")) {
+                if (domain.includes("de1")) {
                   socket.emit("receiveKeyLookup", "not-allowed");
                 } else {
                   socket.emit("receiveKeyLookup", {

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -383,6 +383,7 @@ io.on("connection", (socket) => {
     let subscriptionEnd;
     let success = false;
     const servers = [
+      { domain: "de1.tunnelsats.com", country: "eu" },
       { domain: "de2.tunnelsats.com", country: "eu2" },
       { domain: "us1.tunnelsats.com", country: "na" },
       { domain: "sg1.tunnelsats.com", country: "as" },
@@ -412,12 +413,16 @@ io.on("connection", (socket) => {
                 logDim("SubscriptionEnd: ", date.toISOString());
                 subscriptionEnd = date;
 
-                socket.emit("receiveKeyLookup", {
-                  keyID,
-                  subscriptionEnd,
-                  domain,
-                  country,
-                });
+                if (domain == "de1.tunnelsats.com") {
+                  socket.emit("receiveKeyLookup", "not-allowed");
+                } else {
+                  socket.emit("receiveKeyLookup", {
+                    keyID,
+                    subscriptionEnd,
+                    domain,
+                    country,
+                  });
+                }
 
                 return true;
               })

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -413,7 +413,7 @@ io.on("connection", (socket) => {
                 logDim("SubscriptionEnd: ", date.toISOString());
                 subscriptionEnd = date;
 
-                if (domain.match(servers[0].domain)) {
+                if (domain.includes("de1.tunnelsats.com")) {
                   socket.emit("receiveKeyLookup", "not-allowed");
                 } else {
                   socket.emit("receiveKeyLookup", {


### PR DESCRIPTION
This feature branch adjusts the frontend behaviour for renewals to guide new customers and renewable subscriptions to our new EU vpn (de2) due to capacity limitations of de1.

- new subscriptions retrieve de2 config
- renewable subscriptions of de1 get an error popup saying they need to get a new subscription
- popup message is generalized for multiple usage
- simplified and converted world map