### PR TITLE
killswitch raspiblitz

### DIFF
--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -365,6 +365,7 @@ PostUp = nft add table ip %i\n
 PostUp = nft add chain ip %i prerouting '{type filter hook prerouting priority mangle -1; policy accept;}'; nft add rule ip %i prerouting meta mark set ct mark\n
 PostUp = nft add chain ip %i mangle '{type route hook output priority mangle -1; policy accept;}'; nft add rule ip %i mangle tcp sport != { 8080, 10009 } meta mark != 0x3333 meta cgroup 1118498 meta mark set 0xdeadbeef\n
 PostUp = nft add chain ip %i nat'{type nat hook postrouting priority srcnat -1; policy accept;}'; nft insert rule ip %i nat  fib daddr type != local ip daddr != {$localNetworks} oifname != %i ct mark 0xdeadbeef drop;nft add rule ip %i nat oifname %i ct mark 0xdeadbeef masquerade\n
+PostUp = nft insert rule ip %i nat skuid "bitcoin" fib  daddr type != local ip daddr != {$localNetworks}  meta oifname != %i  meta l4proto { tcp, udp } th dport != { 51820 } counter drop
 PostUp = nft add chain ip %i postroutingmangle'{type filter hook postrouting priority mangle -1; policy accept;}'; nft add rule ip %i postroutingmangle meta mark 0xdeadbeef ct mark set meta mark\n
 PostUp = nft add chain ip %i input'{type filter hook input priority filter -1; policy accept;}'; nft add rule ip %i input iifname %i  ct state established,related counter accept; nft add rule ip %i input iifname %i tcp dport != 9735 counter drop; nft add rule ip %i input iifname %i udp dport != 9735 counter drop\n
 


### PR DESCRIPTION
This prevents any strange user behaviour in dropping all traffic for bitcoin user which does not use the tunnel and originates form the bitcoin user which is used for lightning and bitcoin in raspiblitz OS