### PR TITLE
Separate fwmark

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -284,6 +284,29 @@ As of commit [24f0f3c](https://github.com/blckbx/tunnelsats/commit/24f0f3c969cac
 
 <br />
 
+### Is it possible to run another Wireguard Tunnel besides Tunnelsats?
+
+In case you also want to run another tunnel besides the tunnelsats network, that works!
+Just create another wireguad configfile with new private and public keys of the respective servers.
+
+```
+[Interface]
+PrivateKey = XXX
+Address = XXX (Don't use 10.9.0.0/24 because this is the tunnelsats network)
+Table = off
+[Peer]
+PublicKey = XXX
+Endpoint =  XXX
+AllowedIPs = 0.0.0.0/0
+```
+
+Replace the XXX-values with your own!
+
+Then just bring the interface up with `wg-quick up NAMEOFCONFIGFILE.conf`
+Now you are connected to your second wireguard network.
+
+<br />
+
 ### Phasing out de2.tunnelsats.com - How to switch to de3.tunnelsats.com
 
 Problems with one of our providers forced us to switch to a new one, so we phasing out `de2.tunnelsats.com` slowly. If you are running your node on this VPN (EU continent), please take a minute to read how to switch your connection to the new vpn: `de3.tunnelsats.com`
@@ -294,6 +317,7 @@ In fact there are five simple steps to take:
 2. Fetch latest version of setup script: `wget -O setupv2.sh https://github.com/blckbx/tunnelsats/raw/main/scripts/setupv2.sh`
 3. Run it: `sudo bash setupv2.sh`
 4. Edit your lightning config file and change the DNS entry accordingly:
+
    - LND: `externalhosts=de3.tunnelsats.com:<yourVPNport>`
    - CLN: `announce-addr=de3.tunnelsats.com:<yourVPNport>`
    - As always before changing the config, it is good practice to backup your config.

--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -389,6 +389,7 @@ fi
 # and copy to destination folder
 echo "Copy wireguard conf file to /etc/wireguard and apply network rules..."
 inputDocker="\n
+#Tunnelsats-Setupv2-Docker\n
 [Interface]\n
 DNS = 8.8.8.8\n
 Table = off\n
@@ -409,6 +410,7 @@ PostDown = ip route flush table 51820\n
 PostDown = sysctl -w net.ipv4.conf.all.rp_filter=1\n
 "
 inputNonDocker="\n
+#Tunnelsats-Setupv2-Non-Docker\n
 [Interface]\n
 FwMark = 0x2000000\n
 Table = off\n
@@ -452,13 +454,14 @@ if [ -f "$directory"/tunnelsatsv2.conf ]; then
   fi
 
   # check
-  check=$(grep -c "FwMark" /etc/wireguard/tunnelsatsv2.conf)
+  check=$(grep -c "Tunnelsats-Setupv2" /etc/wireguard/tunnelsatsv2.conf)
   if [ $check -gt 0 ]; then
     echo "> network rules applied"
     echo
   else
     echo "> ERR: network rules not applied"
     echo
+    exit 1
   fi
 fi
 

--- a/scripts/setupv2.sh
+++ b/scripts/setupv2.sh
@@ -371,7 +371,7 @@ sleep 2
 # Fetch all local networks and exclude them from kill switch
 localNetworks=$(ip route | awk '{print $1}' | grep -v default | sed -z 's/\n/, /g')
 
-if [ -z $localNetworks ]; then
+if [ -z "$localNetworks" ]; then
   # add default networks according to RFC 1918
   localNetworks="10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16"
 fi


### PR DESCRIPTION
This PR fixes 2 issues:

1. Allows now virtualized configurations and fails prematurely and requiring userspace wireguard (does not automatically install it). Fixes #78 
2. Adds listen directive recommendation for the lnd.conf 

3. Separates the fwmark and ct mark for the tunnelsats system. This allows other services for example non-docker tailscale installation to run in parallel with tunnelsats.com. It also creates a clean way to add other wireguard tunnels in parallel.